### PR TITLE
Document SPIR-V tools compatibility pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,8 @@ requirements:
     - llvm-spirv {{ llvm_version }}  # [linux]
     - libopencl-devel
     - rocm-device-libs  # [linux and x86_64]
+    # LLVM 16-19's llvm-spirv packages are not compatible with spirv-tools 2026.
+    # Revisit this pin when moving the Linux LLVM/SPIR-V matrix to LLVM 21+.
     - spirv-tools <2026  # [linux]
     {% if cuda_compiler_version != "None" %}
     # cuda-compat is needed for libcuda.so.1


### PR DESCRIPTION
This adds an adjacent recipe comment for the existing `spirv-tools <2026` Linux pin.

Context: PR #31 is the SPIR-V tools 2026 bot migration, but the current AdaptiveCpp feedstock matrix still uses LLVM 16-19. Those matching `llvm-spirv` packages are not compatible with `spirv-tools 2026`, so that migration needs a deliberate LLVM 21+ SPIR-V toolchain update rather than a straight bot rebuild.

This is documentation-only: no build number change and no rerendered files.

Local validation:
- `conda-smithy recipe-lint --conda-forge recipe`