### PR TITLE
Add AdaptiveCpp runtime regression tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
       - patches/0002-Fall-back-missing-functions.patch  # [linux]
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage('adaptivecpp', max_pin='x.x') }}
   ignore_run_exports:
@@ -71,6 +71,8 @@ requirements:
     - libllvm{{ llvm_version }}
     - libnuma  # [linux]
     - llvm {{ llvm_version }}
+    # The generic/OpenMP runtime JIT invokes opt/llc from the matching LLVM.
+    - llvm-tools {{ llvm_version }}  # [not win]
     - llvm-openmp {{ llvm_version }}  # [osx]
     - rocm-device-libs  # [linux and x86_64]
     {% if cuda_compiler_version != "None" %}
@@ -85,10 +87,19 @@ test:
     - test -f $PREFIX/lib/hipSYCL/librt-backend-omp${SHLIB_EXT}  # [not win]
     - test -f $PREFIX/lib/hipSYCL/librt-backend-ocl${SHLIB_EXT}  # [linux]
     - test -f $PREFIX/lib/hipSYCL/librt-backend-hip${SHLIB_EXT}  # [linux and x86_64]
+    - test -f $PREFIX/lib/hipSYCL/bitcode/libkernel-sscp-host-full.bc  # [linux]
+    - test ! -e $PREFIX/lib/lib/hipSYCL/bitcode/libkernel-sscp-host-full.bc  # [linux]
+    - test -x $PREFIX/bin/opt-{{ llvm_version }}  # [linux]
+    - test -x $PREFIX/bin/llc-{{ llvm_version }}  # [linux]
+    - "! grep -R \"_build_env.*/nvvm/libdevice\\|/lib/lib/hipSYCL/bitcode\" $PREFIX/etc/AdaptiveCpp $PREFIX/lib/cmake/AdaptiveCpp"  # [linux]
     {% if cuda_compiler_version != "None" %}
     - test -f $PREFIX/lib/hipSYCL/librt-backend-cuda${SHLIB_EXT}  # [not win]
+    - test -f $PREFIX/nvvm/libdevice/libdevice.10.bc  # [linux and x86_64]
     {% endif %}
     - acpp-info  # [not win]
+    - cmake -S tests -B test-build -G Ninja  # [linux and x86_64 and cuda_compiler_version == "None"]
+    - cmake --build test-build  # [linux and x86_64 and cuda_compiler_version == "None"]
+    - ACPP_VISIBILITY_MASK=omp ./test-build/adaptivecpp-example  # [linux and x86_64 and cuda_compiler_version == "None"]
     - if not exist %PREFIX%\\Library\\include\\AdaptiveCpp\\SYCL\\sycl.hpp exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\cmake\\AdaptiveCpp\\adaptivecpp-config.cmake exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\acpp-common.lib exit 1  # [win]
@@ -104,6 +115,7 @@ test:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - clangdev
+    - clangxx {{ llvm_version }}  # [linux]
     - cmake
     - ninja  # [unix]
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,8 +89,8 @@ test:
     - test -f $PREFIX/lib/hipSYCL/librt-backend-hip${SHLIB_EXT}  # [linux and x86_64]
     - test -f $PREFIX/lib/hipSYCL/bitcode/libkernel-sscp-host-full.bc  # [linux]
     - test ! -e $PREFIX/lib/lib/hipSYCL/bitcode/libkernel-sscp-host-full.bc  # [linux]
-    - test -x $PREFIX/bin/opt-{{ llvm_version }}  # [linux]
-    - test -x $PREFIX/bin/llc-{{ llvm_version }}  # [linux]
+    - "test -x $PREFIX/bin/opt-{{ llvm_version }} || test -x $PREFIX/bin/opt"  # [linux]
+    - "test -x $PREFIX/bin/llc-{{ llvm_version }} || test -x $PREFIX/bin/llc"  # [linux]
     - "! grep -R \"_build_env.*/nvvm/libdevice\\|/lib/lib/hipSYCL/bitcode\" $PREFIX/etc/AdaptiveCpp $PREFIX/lib/cmake/AdaptiveCpp"  # [linux]
     {% if cuda_compiler_version != "None" %}
     - test -f $PREFIX/lib/hipSYCL/librt-backend-cuda${SHLIB_EXT}  # [not win]

--- a/recipe/tests/main.cpp
+++ b/recipe/tests/main.cpp
@@ -55,6 +55,22 @@ int main(int argc, char** argv) {
       std::cout << "--------------------------------------\n\n";
     }
 
+    int value = 0;
+    sycl::queue queue{sycl::default_selector_v};
+    {
+      sycl::buffer<int, 1> buffer{&value, sycl::range<1>{1}};
+      queue.submit([&](sycl::handler& handler) {
+        auto output = buffer.get_access<sycl::access::mode::write>(handler);
+        handler.single_task([=]() { output[0] = 42; });
+      });
+      queue.wait_and_throw();
+    }
+
+    if (value != 42) {
+      std::cerr << "Unexpected kernel result: " << value << "\n";
+      return 1;
+    }
+
   } catch (sycl::exception const& e) {
     std::cerr << "SYCL Exception: " << e.what() << "\n";
     return 1;


### PR DESCRIPTION
Closes #22.
Refs #32.

This adds runtime evidence for the AdaptiveCpp backend path issues instead of only checking package files.

Changes:
- bump the build number
- add `llvm-tools {{ llvm_version }}` to runtime requirements so the generic/OpenMP runtime JIT has the matching `opt-<llvm>` and `llc-<llvm>` tools it invokes
- extend Linux tests to assert the host bitcode is at `$PREFIX/lib/hipSYCL/bitcode`, not the historical `$PREFIX/lib/lib/hipSYCL/bitcode` path
- assert CUDA builds package `$PREFIX/nvvm/libdevice/libdevice.10.bc`
- reject stale build-env `nvvm/libdevice` paths in installed AdaptiveCpp config/cmake files
- compile and run the existing SYCL example on the OpenMP backend for Linux x86_64 CPU builds so the test actually exercises the runtime JIT path

Local validation:
- `conda-smithy recipe-lint --conda-forge recipe`
- `git diff --check`
- `conda-smithy rerender -c auto` made no changes
- Linux CPU LLVM 19 output solve: `adaptivecpp-25.10.0-cpu_llvm19_hebd488c_3.conda`
- Linux CUDA 13 LLVM 19 output solve: `adaptivecpp-25.10.0-cuda130_llvm19_h942e77e_3.conda`
- isolated local runtime reproduction: the SYCL kernel failed before installing `llvm-tools=19` with `LLVMToHost: opt invocation failed`; after installing `llvm-tools=19`, the same OpenMP runtime JIT test passed
