### PR TITLE
Avoid fetching AdaptiveCpp build dependencies

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,10 +24,20 @@ cmake_extra_args=()
 
 if [[ "${target_platform}" == linux* ]]; then
   cmake_extra_args+=("-DACPP_LLD_PATH=${PREFIX}/bin/ld.lld")
+  cmake_extra_args+=("-DACPP_OPENCL_HEADERS_SOURCE_DIR=${SRC_DIR}/opencl-headers")
+  cmake_extra_args+=("-DACPP_OPENCL_CLHPP_SOURCE_DIR=${SRC_DIR}/opencl-clhpp")
+  cmake_extra_args+=("-DACPP_LLVMSPIRV_SOURCE_DIR=${SRC_DIR}/acpp-spirv-llvm-translator")
+  cmake_extra_args+=("-DACPP_SPIRV_HEADERS_SOURCE_DIR=${PREFIX}")
+  cmake_extra_args+=("-DFETCHCONTENT_FULLY_DISCONNECTED=ON")
 
   if [[ "${target_platform}" != "${build_platform}" ]]; then
     cmake_extra_args+=("-DACPP_HOST_FORCE_MCPU_TARGET=generic")
   fi
+
+  test -f "${PREFIX}/include/spirv/unified1/spirv.hpp"
+  test -f "${SRC_DIR}/opencl-headers/CL/cl.h"
+  test -f "${SRC_DIR}/opencl-clhpp/include/CL/opencl.hpp"
+  test -f "${SRC_DIR}/acpp-spirv-llvm-translator/CMakeLists.txt"
 fi
 
 if [[ "${with_rocm_backend}" == ON ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,17 @@
 {% set name = "AdaptiveCpp" %}
 {% set version = "25.10.0" %}
+{% set llvm_spirv_rev = {
+    "16": "d678e6a2a95849c9985c8d209f67b318999083c6",
+    "17": "21d3f7deabd85dcdebd207d8dc75958ab902e4a4",
+    "18": "530c950568ce80137e1c0876d9afc403455a3cb6",
+    "19": "ed04cf4540ec8b1cda2921c3f2eabc72a9291465",
+} %}
+{% set llvm_spirv_sha256 = {
+    "16": "cabeb13932480edeb53e07797165b2a29ffe9fff82701504e6bb9b9e605c8e64",
+    "17": "b227a5adb4590ba28dd5fa612b96f732847d4b5c6019b4fd94c7397f4ee7b1e9",
+    "18": "4d52536344fe0a4962380ab0316db7e5f35cd218d8fcbdf0c795a7eb57302574",
+    "19": "9098743b0b0e759b02e3e4e1efc1931f51bed87b89296dada072a0eedeb1a06a",
+} %}
 
 package:
   name: {{ name|lower }}
@@ -11,9 +23,19 @@ source:
     patches:
       - patches/0001-Install-tool-binaries-to-the-same-folder-of-lib.patch  # [linux]
       - patches/0002-Fall-back-missing-functions.patch  # [linux]
+      - patches/0003-Use-packaged-dependency-sources.patch  # [linux]
+  - url: https://github.com/AdaptiveCpp/SPIRV-LLVM-Translator/archive/{{ llvm_spirv_rev[llvm_version|string] }}.tar.gz  # [linux]
+    sha256: {{ llvm_spirv_sha256[llvm_version|string] }}  # [linux]
+    folder: acpp-spirv-llvm-translator  # [linux]
+  - url: https://github.com/KhronosGroup/OpenCL-Headers/archive/265df85aec478d14a5c5880d7bb92d7dd52714ef.tar.gz  # [linux]
+    sha256: 07002bdb6107dfc8ab1736c3894ff7f1501029751960c0b2dd6157e43c0b9290  # [linux]
+    folder: opencl-headers  # [linux]
+  - url: https://github.com/KhronosGroup/OpenCL-CLHPP/archive/67d100e70612341707725b6648ccca4c10b0dc31.tar.gz  # [linux]
+    sha256: a6112af8ba2cc8a5248bcc7399624258cb9609b31ccd4a65222bf61893c2c618  # [linux]
+    folder: opencl-clhpp  # [linux]
 
 build:
-  number: 3
+  number: 4
   run_exports:
     - {{ pin_subpackage('adaptivecpp', max_pin='x.x') }}
   ignore_run_exports:
@@ -50,11 +72,11 @@ requirements:
     - lld {{ llvm_version }}  # [not win]
     - llvmdev {{ llvm_version }}
     - llvm-openmp {{ llvm_version }}
-    - llvm-spirv {{ llvm_version }}  # [linux]
     - libopencl-devel
     - rocm-device-libs  # [linux and x86_64]
-    # LLVM 16-19's llvm-spirv packages are not compatible with spirv-tools 2026.
-    # Revisit this pin when moving the Linux LLVM/SPIR-V matrix to LLVM 21+.
+    - spirv-headers  # [linux]
+    # AdaptiveCpp builds its own SPIR-V translator fork from the source above.
+    # Keep SPIRV-Tools below 2026 while the Linux matrix uses LLVM 16-19.
     - spirv-tools <2026  # [linux]
     {% if cuda_compiler_version != "None" %}
     # cuda-compat is needed for libcuda.so.1
@@ -89,6 +111,7 @@ test:
     - test -f $PREFIX/lib/hipSYCL/librt-backend-hip${SHLIB_EXT}  # [linux and x86_64]
     - test -f $PREFIX/lib/hipSYCL/bitcode/libkernel-sscp-host-full.bc  # [linux]
     - test ! -e $PREFIX/lib/lib/hipSYCL/bitcode/libkernel-sscp-host-full.bc  # [linux]
+    - test -x $PREFIX/lib/hipSYCL/llvm-to-backend/llvm-to-spirv-tool  # [linux]
     - "test -x $PREFIX/bin/opt-{{ llvm_version }} || test -x $PREFIX/bin/opt"  # [linux]
     - "test -x $PREFIX/bin/llc-{{ llvm_version }} || test -x $PREFIX/bin/llc"  # [linux]
     - "! grep -R \"_build_env.*/nvvm/libdevice\\|/lib/lib/hipSYCL/bitcode\" $PREFIX/etc/AdaptiveCpp $PREFIX/lib/cmake/AdaptiveCpp"  # [linux]

--- a/recipe/patches/0003-Use-packaged-dependency-sources.patch
+++ b/recipe/patches/0003-Use-packaged-dependency-sources.patch
@@ -1,0 +1,102 @@
+diff --git a/src/compiler/llvm-to-backend/CMakeLists.txt b/src/compiler/llvm-to-backend/CMakeLists.txt
+index 98066dd..c595783 100644
+--- a/src/compiler/llvm-to-backend/CMakeLists.txt
++++ b/src/compiler/llvm-to-backend/CMakeLists.txt
+@@ -181,11 +181,29 @@ if(WITH_SSCP_COMPILER)
+     set(LLVMSPIRV_PATH ${LLVMSPIRV_INSTALLDIR}/bin/llvm-spirv)
+     set(LLVMSPIRV_RELATIVE_PATH ${LLVMSPIRV_RELATIVE_INSTALLDIR}/bin/llvm-spirv)
+ 
+-    ExternalProject_Add(LLVMSpirvTranslator
++    set(ACPP_LLVMSPIRV_SOURCE_DIR "" CACHE PATH
++        "Existing SPIR-V translator source tree to use instead of fetching it")
++    set(ACPP_SPIRV_HEADERS_SOURCE_DIR "" CACHE PATH
++        "Existing SPIR-V-Headers source tree to use instead of fetching it")
++    set(ACPP_LLVMSPIRV_EXTRA_CACHE_ARGS "")
++    if(ACPP_SPIRV_HEADERS_SOURCE_DIR)
++      list(APPEND ACPP_LLVMSPIRV_EXTRA_CACHE_ARGS
++        -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR:PATH=${ACPP_SPIRV_HEADERS_SOURCE_DIR})
++    endif()
++    set(ACPP_LLVMSPIRV_SOURCE_ARGS
+       GIT_REPOSITORY https://github.com/AdaptiveCpp/SPIRV-LLVM-Translator
+       GIT_TAG origin/${LLVMSPIRV_BRANCH}
+       GIT_SHALLOW ON
+-      GIT_REMOTE_UPDATE_STRATEGY CHECKOUT
++      GIT_REMOTE_UPDATE_STRATEGY CHECKOUT)
++    if(ACPP_LLVMSPIRV_SOURCE_DIR)
++      set(ACPP_LLVMSPIRV_SOURCE_ARGS
++        SOURCE_DIR ${ACPP_LLVMSPIRV_SOURCE_DIR}
++        DOWNLOAD_COMMAND ""
++        UPDATE_COMMAND "")
++    endif()
++
++    ExternalProject_Add(LLVMSpirvTranslator
++      ${ACPP_LLVMSPIRV_SOURCE_ARGS}
+       BUILD_ALWAYS OFF
+       BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/ext/llvm-spirv
+       CMAKE_ARGS
+@@ -196,6 +214,7 @@ if(WITH_SSCP_COMPILER)
+         -DLLVM_DIR:PATH=${LLVM_DIR}
+         -DCMAKE_INSTALL_PREFIX:PATH=${LLVMSPIRV_INSTALLDIR}
+         -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
++        ${ACPP_LLVMSPIRV_EXTRA_CACHE_ARGS}
+       BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release --parallel ${ACPP_SUBPROJECT_PARALLEL_JOBS}
+       INSTALL_COMMAND ""
+     )
+diff --git a/src/runtime/CMakeLists.txt b/src/runtime/CMakeLists.txt
+index 9970a93..eae317d 100644
+--- a/src/runtime/CMakeLists.txt
++++ b/src/runtime/CMakeLists.txt
+@@ -237,25 +237,35 @@ if(WITH_LEVEL_ZERO_BACKEND)
+ endif()
+ 
+ if(WITH_OPENCL_BACKEND)
+-  include(FetchContent)
+-  FetchContent_Declare(ocl-headers
+-    GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-Headers
+-    GIT_TAG 265df85aec478d14a5c5880d7bb92d7dd52714ef
+-  )
+-  
+-  FetchContent_MakeAvailable(ocl-headers)
+-  
+-  add_library(ocl-headers INTERFACE)
+-  target_include_directories(ocl-headers INTERFACE ${ocl-headers_SOURCE_DIR})
+-  
+-  FetchContent_Declare(ocl-cxx-headers
+-    GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-CLHPP
+-    GIT_TAG 67d100e70612341707725b6648ccca4c10b0dc31
+-  )
+-  FetchContent_MakeAvailable(ocl-cxx-headers)
+-  
++  set(ACPP_OPENCL_HEADERS_SOURCE_DIR "" CACHE PATH
++      "Existing OpenCL-Headers source tree to use instead of fetching it")
++  set(ACPP_OPENCL_CLHPP_SOURCE_DIR "" CACHE PATH
++      "Existing OpenCL-CLHPP source tree to use instead of fetching it")
++
+   add_library(ocl-cxx-headers INTERFACE)
+-  target_include_directories(ocl-cxx-headers INTERFACE ${ocl-cxx-headers_SOURCE_DIR}/include)
++  add_library(ocl-headers INTERFACE)
++  if(ACPP_OPENCL_HEADERS_SOURCE_DIR AND ACPP_OPENCL_CLHPP_SOURCE_DIR)
++    target_include_directories(ocl-headers INTERFACE ${ACPP_OPENCL_HEADERS_SOURCE_DIR})
++    target_include_directories(ocl-cxx-headers INTERFACE ${ACPP_OPENCL_CLHPP_SOURCE_DIR}/include)
++  else()
++    include(FetchContent)
++    FetchContent_Declare(ocl-headers
++      GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-Headers
++      GIT_TAG 265df85aec478d14a5c5880d7bb92d7dd52714ef
++    )
++
++    FetchContent_MakeAvailable(ocl-headers)
++
++    target_include_directories(ocl-headers INTERFACE ${ocl-headers_SOURCE_DIR})
++
++    FetchContent_Declare(ocl-cxx-headers
++      GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-CLHPP
++      GIT_TAG 67d100e70612341707725b6648ccca4c10b0dc31
++    )
++    FetchContent_MakeAvailable(ocl-cxx-headers)
++
++    target_include_directories(ocl-cxx-headers INTERFACE ${ocl-cxx-headers_SOURCE_DIR}/include)
++  endif()
+ 
+   add_library(rt-backend-ocl SHARED
+     ocl/ocl_backend.cpp


### PR DESCRIPTION
Closes #10.

This updates the Linux recipe path so AdaptiveCpp builds from conda-declared source inputs instead of fetching dependency sources during CMake configure/build:

- declares the AdaptiveCpp/SPIRV-LLVM-Translator source per `llvm_version`
- declares the exact OpenCL-Headers and OpenCL-CLHPP source revisions already expected by AdaptiveCpp
- patches AdaptiveCpp CMake to accept those source directories and disables the translator download/update steps when supplied
- adds build-time assertions for the declared source trees and an installed-tool package test for `lib/hipSYCL/llvm-to-backend/llvm-to-spirv-tool`
- keeps `spirv-tools <2026` while the feedstock matrix uses LLVM 16-19

I also tried replacing the OpenCL header fetch with the conda `clhpp` package, but AdaptiveCpp 25.10.0 expects APIs that are not present there (`enqueueMemcpySVM` / `enqueueMemFillSVM`). Using the exact upstream OpenCL-CLHPP revision as a declared source avoids network fetches without changing that upstream compatibility contract.

Local evidence:

- `conda-smithy recipe-lint --conda-forge recipe` passed
- `git diff --check` passed
- `conda-smithy rerender -c auto` reported no changes, so there is no generated commit in this PR
- `conda build recipe --source -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonellvm_version16.yaml --croot <tmp> -c conda-forge` passed
- `conda build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonellvm_version19.yaml --croot <tmp> -c conda-forge` passed, including package tests
- the LLVM 19 build log showed `No download step`, `No update step`, and `No patch step` for `LLVMSpirvTranslator`, with `ACPP_*_SOURCE_DIR` arguments pointing at recipe source folders
