### PR TITLE
Add AdaptiveCpp clang runtime dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ source:
     folder: opencl-clhpp  # [linux]
 
 build:
-  number: 4
+  number: 5
   run_exports:
     - {{ pin_subpackage('adaptivecpp', max_pin='x.x') }}
   ignore_run_exports:
@@ -88,6 +88,8 @@ requirements:
     {% endif %}
   run:
     - clangdev  # [osx]
+    # The acpp driver defaults to $PREFIX/bin/clang++-<llvm_version>.
+    - clangxx {{ llvm_version }}  # [linux]
     - hip-runtime-amd  # [linux and x86_64]
     - lld {{ llvm_version }}  # [not win]
     - libllvm{{ llvm_version }}
@@ -112,6 +114,7 @@ test:
     - test -f $PREFIX/lib/hipSYCL/bitcode/libkernel-sscp-host-full.bc  # [linux]
     - test ! -e $PREFIX/lib/lib/hipSYCL/bitcode/libkernel-sscp-host-full.bc  # [linux]
     - test -x $PREFIX/lib/hipSYCL/llvm-to-backend/llvm-to-spirv-tool  # [linux]
+    - test -x $PREFIX/bin/clang++-{{ llvm_version }}  # [linux]
     - "test -x $PREFIX/bin/opt-{{ llvm_version }} || test -x $PREFIX/bin/opt"  # [linux]
     - "test -x $PREFIX/bin/llc-{{ llvm_version }} || test -x $PREFIX/bin/llc"  # [linux]
     - "! grep -R \"_build_env.*/nvvm/libdevice\\|/lib/lib/hipSYCL/bitcode\" $PREFIX/etc/AdaptiveCpp $PREFIX/lib/cmake/AdaptiveCpp"  # [linux]
@@ -137,8 +140,7 @@ test:
   requires:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - clangdev
-    - clangxx {{ llvm_version }}  # [linux]
+    - clangdev  # [not linux]
     - cmake
     - ninja  # [unix]
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,7 +88,7 @@ requirements:
     {% endif %}
   run:
     - clangdev  # [osx]
-    # The acpp driver defaults to $PREFIX/bin/clang++-<llvm_version>.
+    # The acpp driver defaults to the clang++ installed by clangxx.
     - clangxx {{ llvm_version }}  # [linux]
     - hip-runtime-amd  # [linux and x86_64]
     - lld {{ llvm_version }}  # [not win]
@@ -114,7 +114,7 @@ test:
     - test -f $PREFIX/lib/hipSYCL/bitcode/libkernel-sscp-host-full.bc  # [linux]
     - test ! -e $PREFIX/lib/lib/hipSYCL/bitcode/libkernel-sscp-host-full.bc  # [linux]
     - test -x $PREFIX/lib/hipSYCL/llvm-to-backend/llvm-to-spirv-tool  # [linux]
-    - test -x $PREFIX/bin/clang++-{{ llvm_version }}  # [linux]
+    - "test -x $PREFIX/bin/clang++-{{ llvm_version }} || test -x $PREFIX/bin/clang++"  # [linux]
     - "test -x $PREFIX/bin/opt-{{ llvm_version }} || test -x $PREFIX/bin/opt"  # [linux]
     - "test -x $PREFIX/bin/llc-{{ llvm_version }} || test -x $PREFIX/bin/llc"  # [linux]
     - "! grep -R \"_build_env.*/nvvm/libdevice\\|/lib/lib/hipSYCL/bitcode\" $PREFIX/etc/AdaptiveCpp $PREFIX/lib/cmake/AdaptiveCpp"  # [linux]


### PR DESCRIPTION
Refs #32.

While checking the published CUDA build for issue #32, a clean installed environment exposed a separate runtime-dependency gap: `acpp` can run `acpp-info`, but Linux packages did not depend on the `clangxx` package that provides the clang++ driver used by `acpp`. A minimal install failed to compile even a small OpenMP SYCL program with:

```text
acpp error: fatal: [Errno 2] No such file or directory: .../bin/clang++-19
```

This PR adds `clangxx {{ llvm_version }}` to Linux runtime requirements, bumps the build number, adds a package test for the installed clang++ driver, and removes the Linux `clangxx` test-only requirement so the existing CMake/OpenMP package test verifies the runtime dependency instead of masking it.

Commits:

- `a061d54` adds the runtime dependency, build-number bump, and package test.
- `ceae498` relaxes the package test to accept either `clang++-{{ llvm_version }}` or unversioned `clang++`; CI showed LLVM 17 exposes the unversioned layout, matching the existing LLVM tools layout differences.

`conda-smithy rerender -c auto` made no generated changes after each manual commit, so there is no generated commit.

Local validation:

- Clean installed env before adding `clangxx`: `acpp --acpp-targets=omp` failed with missing `clang++-19`.
- Same env after installing `clangxx=19`: `acpp --acpp-targets=omp` compiled and the OpenMP kernel test exited 0.
- Isolated `clangxx=17` env confirmed the unversioned `clang++` layout and the relaxed check passed.
- `conda-smithy recipe-lint --conda-forge recipe`
- `git diff --check`
- `conda-smithy rerender -c auto` (no changes)
- `conda build recipe --output -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonellvm_version19.yaml --croot <tmp> -c conda-forge`
- `conda build recipe --output -m .ci_support/linux_64_c_stdlib_version2.28cuda_compiler_version13.0llvm_version19.yaml --croot <tmp> -c conda-forge` (first attempt hit transient HTTP 000 downloading `ninja`; retry passed)
- `conda build recipe -m .ci_support/linux_64_c_stdlib_version2.17cuda_compiler_versionNonellvm_version19.yaml --croot <tmp> -c conda-forge` passed, including package tests and the OpenMP runtime kernel test
