### PR TITLE
Add AdaptiveCpp CMake CUDA compile test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -121,6 +121,8 @@ test:
     {% if cuda_compiler_version != "None" %}
     - test -f $PREFIX/lib/hipSYCL/librt-backend-cuda${SHLIB_EXT}  # [not win]
     - test -f $PREFIX/nvvm/libdevice/libdevice.10.bc  # [linux and x86_64]
+    - cmake -S tests/cmake-cuda-smoke -B test-build-cuda -G Ninja -DACPP_TARGETS=cuda:sm_80  # [linux and x86_64 and cuda_compiler_version == "12.9" and llvm_version == "19"]
+    - ACPP_CUDA_CXX_FLAGS="-I$PREFIX/targets/x86_64-linux/include -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -isystem $PREFIX/include/AdaptiveCpp/hipSYCL/std/hiplike" ACPP_CUDA_LINK_LINE="-Wl,-rpath=$PREFIX/targets/x86_64-linux/lib -L$PREFIX/targets/x86_64-linux/lib -lcudart" cmake --build test-build-cuda  # [linux and x86_64 and cuda_compiler_version == "12.9" and llvm_version == "19"]
     {% endif %}
     - acpp-info  # [not win]
     - cmake -S tests -B test-build -G Ninja  # [linux and x86_64 and cuda_compiler_version == "None"]
@@ -141,6 +143,11 @@ test:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - clangdev  # [not linux]
+    # Test-only CUDA headers let CI compile a CMake AdaptiveCpp CUDA target without a GPU.
+    - cuda-crt-dev_linux-64  # [linux and x86_64 and cuda_compiler_version == "12.9" and llvm_version == "19"]
+    - cuda-cudart-dev        # [linux and x86_64 and cuda_compiler_version == "12.9" and llvm_version == "19"]
+    - cuda-driver-dev        # [linux and x86_64 and cuda_compiler_version == "12.9" and llvm_version == "19"]
+    - libcurand-dev          # [linux and x86_64 and cuda_compiler_version == "12.9" and llvm_version == "19"]
     - cmake
     - ninja  # [unix]
   files:

--- a/recipe/tests/cmake-cuda-smoke/CMakeLists.txt
+++ b/recipe/tests/cmake-cuda-smoke/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+project(adaptivecpp-cuda-compile-smoke)
+
+find_package(AdaptiveCpp CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} cuda_compile_smoke.cpp)
+add_sycl_to_target(TARGET ${PROJECT_NAME} SOURCES cuda_compile_smoke.cpp)

--- a/recipe/tests/cmake-cuda-smoke/cuda_compile_smoke.cpp
+++ b/recipe/tests/cmake-cuda-smoke/cuda_compile_smoke.cpp
@@ -1,0 +1,14 @@
+#include <sycl/sycl.hpp>
+
+int main() {
+  int value = 0;
+  sycl::queue queue{sycl::default_selector_v};
+  sycl::buffer<int, 1> buffer{&value, sycl::range<1>{1}};
+
+  queue.submit([&](sycl::handler& handler) {
+    auto output = buffer.get_access<sycl::access::mode::write>(handler);
+    handler.single_task([=]() { output[0] = 42; });
+  });
+
+  return 0;
+}


### PR DESCRIPTION
This is a narrow testing PR to exercise AdaptiveCpp as an installed compiler through its documented CMake integration.

Refs #32.

It adds an explicit `tests/cmake-cuda-smoke/` project for the Linux CUDA 12.9 / LLVM 19 variant. The smoke project uses `find_package(AdaptiveCpp CONFIG REQUIRED)`, `add_sycl_to_target`, and `ACPP_TARGETS=cuda:sm_80`, then builds a tiny SYCL kernel translation unit with test-only CUDA development headers.

This proves the package/CMake/compile path on CI without requiring GPU hardware or changing runtime dependencies.

Local checks:
- `conda-smithy recipe-lint --conda-forge recipe`
- `git diff --check`
- `conda-smithy rerender -c auto` (no changes)
- Linux CUDA 12.9 / LLVM 19 output solve
- Published-package CMake configure/build smoke test against `adaptivecpp=25.10.0=cuda129_llvm19_hbf29d37_5` with test-only CUDA headers