### PR TITLE
Symlink libdevice.10.bc to ensure it's visible at runtime

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -47,6 +47,10 @@ fi
 
 if [[ "${with_cuda_backend}" == ON && "${target_platform}" == linux-64 ]]; then
   cmake_extra_args+=("-DCUDA_DEVICE_LIBS_PATH=${PREFIX}/nvvm/libdevice")
+  # Link the nvvm device path to the default lookup location of acpp
+  mkdir -p "${PREFIX}/lib/hipSYCL/ext/bitcode/ptx"
+  ln -sf ../../../../../nvvm/libdevice/libdevice.10.bc \
+    "${PREFIX}/lib/hipSYCL/ext/bitcode/ptx/libdevice.10.bc"
 fi
 
 # Workaround for GCC 14 on AArch64 expanding __arm_* keyword-attributes to [[arm::...]]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   name: AdaptiveCpp
   version: "25.10.0"
-  build_number: 6
+  build_number: 7
 
 package:
   name: ${{ name|lower }}
@@ -205,6 +205,10 @@ tests:
         then: test -f $PREFIX/lib/hipSYCL/librt-backend-cuda${SHLIB_EXT}
       - if: cuda_compiler_version != "None" and linux and x86_64
         then: test -f $PREFIX/nvvm/libdevice/libdevice.10.bc
+      - if: cuda_compiler_version != "None" and linux and x86_64
+        then: test -L $PREFIX/lib/hipSYCL/ext/bitcode/ptx/libdevice.10.bc
+      - if: cuda_compiler_version != "None" and linux and x86_64
+        then: test -f $PREFIX/lib/hipSYCL/ext/bitcode/ptx/libdevice.10.bc
       - if: not win
         then: bash run_cmake_test.sh
       - if: linux and x86_64 and cuda_compiler_version == "12.9" and llvm_version == "19"


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Fix #41 JIT libdevice.10.bc resolution by symlinking the file from nvvm location (conda providing package) to the default search location at `${PREFIX}/lib/hipSYCL/ext/bitcode/ptx/libdevice.10.bc`

This fixes crashes due to incorrect file lookup in acpp when using the CUDA JIT
