### PR TITLE
Clean up platform and build dependencies

### DIFF
--- a/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version16.yaml
+++ b/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version16.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '16'
 spirv_tools:

--- a/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version17.yaml
+++ b/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version17.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '17'
 spirv_tools:

--- a/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version18.yaml
+++ b/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version18.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '18'
 spirv_tools:

--- a/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version19.yaml
+++ b/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version19.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '19'
 spirv_tools:

--- a/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version16.yaml
+++ b/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version16.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '16'
 spirv_tools:

--- a/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version17.yaml
+++ b/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version17.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '17'
 spirv_tools:

--- a/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version18.yaml
+++ b/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version18.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '18'
 spirv_tools:

--- a/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version19.yaml
+++ b/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version19.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '19'
 spirv_tools:

--- a/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version16.yaml
+++ b/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version16.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '16'
 spirv_tools:

--- a/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version17.yaml
+++ b/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version17.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '17'
 spirv_tools:

--- a/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version18.yaml
+++ b/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version18.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '18'
 spirv_tools:

--- a/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version19.yaml
+++ b/.ci_support/linux_64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version19.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '19'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version16.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version16.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '16'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version17.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version17.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '17'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version18.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version18.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '18'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version19.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.17cuda_compiler_version12.9cxx_compiler_version14llvm_version19.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '19'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version16.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version16.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '16'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version17.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version17.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '17'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version18.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version18.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '18'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version19.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version19.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '19'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version16.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version16.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '16'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version17.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version17.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '17'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version18.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version18.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '18'
 spirv_tools:

--- a/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version19.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version15c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version15llvm_version19.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '19'
 spirv_tools:

--- a/.ci_support/linux_ppc64le_llvm_version16.yaml
+++ b/.ci_support/linux_ppc64le_llvm_version16.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '16'
 spirv_tools:

--- a/.ci_support/linux_ppc64le_llvm_version17.yaml
+++ b/.ci_support/linux_ppc64le_llvm_version17.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '17'
 spirv_tools:

--- a/.ci_support/linux_ppc64le_llvm_version18.yaml
+++ b/.ci_support/linux_ppc64le_llvm_version18.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '18'
 spirv_tools:

--- a/.ci_support/linux_ppc64le_llvm_version19.yaml
+++ b/.ci_support/linux_ppc64le_llvm_version19.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-libboost_devel:
-- '1.90'
 llvm_version:
 - '19'
 spirv_tools:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -20,8 +20,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libboost_devel:
-- '1.90'
 llvm_version:
 - '19'
 macos_machine:

--- a/.ci_support/osx_arm64_llvm_version16.yaml
+++ b/.ci_support/osx_arm64_llvm_version16.yaml
@@ -20,8 +20,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '21'
-libboost_devel:
-- '1.90'
 llvm_version:
 - '16'
 macos_machine:

--- a/.ci_support/osx_arm64_llvm_version17.yaml
+++ b/.ci_support/osx_arm64_llvm_version17.yaml
@@ -20,8 +20,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '21'
-libboost_devel:
-- '1.90'
 llvm_version:
 - '17'
 macos_machine:

--- a/.ci_support/osx_arm64_llvm_version18.yaml
+++ b/.ci_support/osx_arm64_llvm_version18.yaml
@@ -20,8 +20,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '21'
-libboost_devel:
-- '1.90'
 llvm_version:
 - '18'
 macos_machine:

--- a/.ci_support/osx_arm64_llvm_version19.yaml
+++ b/.ci_support/osx_arm64_llvm_version19.yaml
@@ -20,8 +20,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '21'
-libboost_devel:
-- '1.90'
 llvm_version:
 - '19'
 macos_machine:

--- a/.ci_support/win_64_cuda_compiler_version12.9llvm_version16.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9llvm_version16.yaml
@@ -12,8 +12,6 @@ cuda_compiler_version:
 - '12.9'
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 llvm_version:
 - '16'
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version12.9llvm_version17.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9llvm_version17.yaml
@@ -12,8 +12,6 @@ cuda_compiler_version:
 - '12.9'
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 llvm_version:
 - '17'
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version12.9llvm_version18.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9llvm_version18.yaml
@@ -12,8 +12,6 @@ cuda_compiler_version:
 - '12.9'
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 llvm_version:
 - '18'
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_version12.9llvm_version19.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9llvm_version19.yaml
@@ -12,8 +12,6 @@ cuda_compiler_version:
 - '12.9'
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 llvm_version:
 - '19'
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonellvm_version16.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonellvm_version16.yaml
@@ -12,8 +12,6 @@ cuda_compiler_version:
 - None
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 llvm_version:
 - '16'
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonellvm_version17.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonellvm_version17.yaml
@@ -12,8 +12,6 @@ cuda_compiler_version:
 - None
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 llvm_version:
 - '17'
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonellvm_version18.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonellvm_version18.yaml
@@ -12,8 +12,6 @@ cuda_compiler_version:
 - None
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 llvm_version:
 - '18'
 target_platform:

--- a/.ci_support/win_64_cuda_compiler_versionNonellvm_version19.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonellvm_version19.yaml
@@ -12,8 +12,6 @@ cuda_compiler_version:
 - None
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 llvm_version:
 - '19'
 target_platform:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,7 +31,7 @@ cmake_extra_args=()
 
 if [[ "${target_platform}" == linux* ]]; then
   cmake_extra_args+=("-DACPP_LLD_PATH=${PREFIX}/bin/ld.lld")
-  cmake_extra_args+=("-DACPP_OPENCL_HEADERS_SOURCE_DIR=${SRC_DIR}/opencl-headers")
+  cmake_extra_args+=("-DACPP_OPENCL_HEADERS_SOURCE_DIR=${PREFIX}/include")
   cmake_extra_args+=("-DACPP_OPENCL_CLHPP_SOURCE_DIR=${SRC_DIR}/opencl-clhpp")
   cmake_extra_args+=("-DACPP_LLVMSPIRV_SOURCE_DIR=${SRC_DIR}/acpp-spirv-llvm-translator")
   cmake_extra_args+=("-DACPP_SPIRV_HEADERS_SOURCE_DIR=${PREFIX}")
@@ -52,7 +52,7 @@ if [[ "${target_platform}" == linux* ]]; then
   fi
 
   test -f "${PREFIX}/include/spirv/unified1/spirv.hpp"
-  test -f "${SRC_DIR}/opencl-headers/CL/cl.h"
+  test -f "${PREFIX}/include/CL/cl.h"
   test -f "${SRC_DIR}/opencl-clhpp/include/CL/opencl.hpp"
   test -f "${SRC_DIR}/acpp-spirv-llvm-translator/CMakeLists.txt"
 fi

--- a/recipe/patches/0003-Use-packaged-dependency-sources.patch
+++ b/recipe/patches/0003-Use-packaged-dependency-sources.patch
@@ -43,10 +43,10 @@ index 98066dd..c595783 100644
        INSTALL_COMMAND ""
      )
 diff --git a/src/runtime/CMakeLists.txt b/src/runtime/CMakeLists.txt
-index 9970a93..eae317d 100644
+index 9970a93..fcb4a08 100644
 --- a/src/runtime/CMakeLists.txt
 +++ b/src/runtime/CMakeLists.txt
-@@ -237,25 +237,35 @@ if(WITH_LEVEL_ZERO_BACKEND)
+@@ -237,25 +237,39 @@ if(WITH_LEVEL_ZERO_BACKEND)
  endif()
  
  if(WITH_OPENCL_BACKEND)
@@ -58,7 +58,12 @@ index 9970a93..eae317d 100644
 -  
 -  FetchContent_MakeAvailable(ocl-headers)
 -  
--  add_library(ocl-headers INTERFACE)
++  set(ACPP_OPENCL_HEADERS_SOURCE_DIR "" CACHE PATH
++      "Existing OpenCL-Headers include directory to use instead of fetching it")
++  set(ACPP_OPENCL_CLHPP_SOURCE_DIR "" CACHE PATH
++      "Existing OpenCL-CLHPP source tree to use instead of fetching it")
++
+   add_library(ocl-headers INTERFACE)
 -  target_include_directories(ocl-headers INTERFACE ${ocl-headers_SOURCE_DIR})
 -  
 -  FetchContent_Declare(ocl-cxx-headers
@@ -67,17 +72,8 @@ index 9970a93..eae317d 100644
 -  )
 -  FetchContent_MakeAvailable(ocl-cxx-headers)
 -  
-+  set(ACPP_OPENCL_HEADERS_SOURCE_DIR "" CACHE PATH
-+      "Existing OpenCL-Headers source tree to use instead of fetching it")
-+  set(ACPP_OPENCL_CLHPP_SOURCE_DIR "" CACHE PATH
-+      "Existing OpenCL-CLHPP source tree to use instead of fetching it")
-+
-   add_library(ocl-cxx-headers INTERFACE)
--  target_include_directories(ocl-cxx-headers INTERFACE ${ocl-cxx-headers_SOURCE_DIR}/include)
-+  add_library(ocl-headers INTERFACE)
-+  if(ACPP_OPENCL_HEADERS_SOURCE_DIR AND ACPP_OPENCL_CLHPP_SOURCE_DIR)
++  if(ACPP_OPENCL_HEADERS_SOURCE_DIR)
 +    target_include_directories(ocl-headers INTERFACE ${ACPP_OPENCL_HEADERS_SOURCE_DIR})
-+    target_include_directories(ocl-cxx-headers INTERFACE ${ACPP_OPENCL_CLHPP_SOURCE_DIR}/include)
 +  else()
 +    include(FetchContent)
 +    FetchContent_Declare(ocl-headers
@@ -88,7 +84,14 @@ index 9970a93..eae317d 100644
 +    FetchContent_MakeAvailable(ocl-headers)
 +
 +    target_include_directories(ocl-headers INTERFACE ${ocl-headers_SOURCE_DIR})
++  endif()
 +
+   add_library(ocl-cxx-headers INTERFACE)
+-  target_include_directories(ocl-cxx-headers INTERFACE ${ocl-cxx-headers_SOURCE_DIR}/include)
++  if(ACPP_OPENCL_CLHPP_SOURCE_DIR)
++    target_include_directories(ocl-cxx-headers INTERFACE ${ACPP_OPENCL_CLHPP_SOURCE_DIR}/include)
++  else()
++    include(FetchContent)
 +    FetchContent_Declare(ocl-cxx-headers
 +      GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-CLHPP
 +      GIT_TAG 67d100e70612341707725b6648ccca4c10b0dc31

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   name: AdaptiveCpp
   version: "25.10.0"
-  build_number: 9
+  build_number: 10
 
 package:
   name: ${{ name|lower }}
@@ -73,13 +73,8 @@ requirements:
     - ${{ compiler("cxx") }}
     - ${{ stdlib("c") }}
     - cmake
-    - doxygen
-    - if: linux
-      then: make
     - if: not win
       then: ninja
-    - if: linux
-      then: pkgconfig
     - if: cuda_compiler_version != "None"
       then: ${{ compiler("cuda") }}
     - if: cuda_compiler_version != "None" and build_platform != target_platform
@@ -94,12 +89,15 @@ requirements:
     - clangdev
     - if: linux and x86_64
       then: hipcc
-    - libboost-devel
     - if: not win
       then: lld ${{ llvm_version }}.*
     - llvmdev ${{ llvm_version }}.*
     - llvm-openmp ${{ llvm_version }}.*
-    - libopencl-devel
+    # AdaptiveCpp enables NUMA support when the headers and library are present.
+    - if: linux
+      then: libnuma
+    - if: linux
+      then: libopencl-devel
     - if: linux and x86_64
       then: rocm-device-libs
     - if: linux
@@ -148,7 +146,6 @@ requirements:
     - ${{ pin_subpackage("adaptivecpp", upper_bound="x.x") }}
   ignore_run_exports:
     by_name:
-      - libboost
       - llvm
       - if: not win
         then: llvm-openmp

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,16 +13,24 @@ source:
   - url: https://github.com/AdaptiveCpp/AdaptiveCpp/archive/v${{ version }}.tar.gz
     sha256: 334b16ebff373bd2841f83332c2ae9a45ec192f2cf964d5fdfe94e1140776059
     patches:
+      # Drop once upstream installs the llvm-to-backend tools next to their
+      # libraries, or gives the upstream bin/ layout a working relocatable RPATH.
       - if: linux
         then: patches/0001-Install-tool-binaries-to-the-same-folder-of-lib.patch
+      # Drop once the packaged release includes AdaptiveCpp/AdaptiveCpp#1956.
       - if: linux
         then: patches/0002-Fall-back-missing-functions.patch
+      # Drop once upstream supports an offline external OpenCL header setup and
+      # an externally supplied AdaptiveCpp SPIR-V translator source (see
+      # AdaptiveCpp/AdaptiveCpp#1611).
       - if: linux
         then: patches/0003-Use-packaged-dependency-sources.patch
       # Drop this downstream patch once AdaptiveCpp/AdaptiveCpp#2185 is merged
       # and the packaged AdaptiveCpp release includes the fix.
       - if: linux
         then: patches/0004-Cross-compile-native-bitcode-tools.patch
+  # AdaptiveCpp's translator fork has required address-space handling from
+  # AdaptiveCpp/AdaptiveCpp#1825; conda-forge's llvm-spirv is not interchangeable.
   - if: linux and llvm_version == "16"
     then:
       url: https://github.com/AdaptiveCpp/SPIRV-LLVM-Translator/archive/d678e6a2a95849c9985c8d209f67b318999083c6.tar.gz
@@ -43,11 +51,7 @@ source:
       url: https://github.com/AdaptiveCpp/SPIRV-LLVM-Translator/archive/ed04cf4540ec8b1cda2921c3f2eabc72a9291465.tar.gz
       sha256: 9098743b0b0e759b02e3e4e1efc1931f51bed87b89296dada072a0eedeb1a06a
       target_directory: acpp-spirv-llvm-translator
-  - if: linux
-    then:
-      url: https://github.com/KhronosGroup/OpenCL-Headers/archive/265df85aec478d14a5c5880d7bb92d7dd52714ef.tar.gz
-      sha256: 07002bdb6107dfc8ab1736c3894ff7f1501029751960c0b2dd6157e43c0b9290
-      target_directory: opencl-headers
+  # OpenCL-CLHPP is not packaged by conda-forge, so provide its source offline.
   - if: linux
     then:
       url: https://github.com/KhronosGroup/OpenCL-CLHPP/archive/67d100e70612341707725b6648ccca4c10b0dc31.tar.gz

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -79,6 +79,8 @@ requirements:
     - cmake
     - if: not win
       then: ninja
+    - if: linux
+      then: pkg-config
     - if: cuda_compiler_version != "None"
       then: ${{ compiler("cuda") }}
     - if: cuda_compiler_version != "None" and build_platform != target_platform
@@ -134,8 +136,6 @@ requirements:
     - if: not win
       then: lld ${{ llvm_version }}.*
     - libllvm${{ llvm_version }}
-    - if: linux
-      then: libnuma
     - llvm ${{ llvm_version }}.*
     # The generic/OpenMP runtime JIT invokes opt/llc from the matching LLVM.
     - if: not win


### PR DESCRIPTION
**Why:** The recipe enabled OpenCL only on Linux but installed its development package on every platform, and declared `libnuma` only at runtime even though AdaptiveCpp detects NUMA support while configuring. The build also carried unused tools and Boost, and `pkgconfig` selected a Python wrapper instead of the `pkg-config` executable used by CMake.

**What:** Align dependencies with the features each platform actually builds, use conda-forge's packaged OpenCL C headers, and document when each downstream patch can be removed.

**How:**

- **Platform requirements** -- make `libopencl-devel` Linux-only and move `libnuma` into Linux host requirements, relying on its run export for the ABI-constrained runtime dependency.
- **Build inputs** -- remove unused Doxygen, Make, and Boost requirements; replace `pkgconfig` with the actual `pkg-config` executable package.
- **Vendored sources** -- consume the C headers already supplied by `libopencl-devel`. Keep OpenCL-CLHPP because conda-forge has no corresponding package, and keep AdaptiveCpp's SPIR-V translator fork because its address-space patch from AdaptiveCpp/AdaptiveCpp#1825 is not present in conda-forge's upstream `llvm-spirv` package.
- **Patch lifecycle** -- record concrete removal conditions for all four downstream patches, including AdaptiveCpp/AdaptiveCpp#1956, AdaptiveCpp/AdaptiveCpp#1611, and AdaptiveCpp/AdaptiveCpp#2185.
- **Packaging** -- bump the build number to 10 and rerender; generated CI changes only remove the obsolete Boost variant entries.

**Evidence:** The finalized Linux package contains one `libnuma >=2.0.18,<3.0a0` runtime requirement, and `librt-backend-omp.so` has a `NEEDED` entry for `libnuma.so.1`. Linux CPU, CUDA 12.9, CUDA 13.0, AArch64, macOS x86_64/ARM64, and Windows representative variants all render and solve. Non-Linux variants no longer render an OpenCL dependency.

**Test plan:**

```console
rattler-build build --recipe recipe/recipe.yaml --target-platform linux-64 --variant-config .ci_support/linux_64_c_compiler_version15c_stdlib_version2.17cuda_compiler_versionNonecxx_compiler_version15llvm_version19.yaml --output-dir /tmp/acpp-rattler-final-build
```
Run URL: local only (no run URL emitted)

Result: full package build and all installed-package tests passed, including CMake consumers, `acpp-info`, and an OpenMP execution test.

```console
conda-smithy recipe-lint --conda-forge recipe
```
Run URL: local only (no run URL emitted)

Result: `recipe is in fine form`.
